### PR TITLE
Multiple minor updates

### DIFF
--- a/charts/lightstepsatellite/CHANGELOG.md
+++ b/charts/lightstepsatellite/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ENHANCEMENTS:
 
-* Changed the defaults of service accounts for running the satellite. This wil prevent insufficient errors when running the pods
+* Changed the defaults of service accounts for running the satellite. This wil prevent insufficient permissions errors when running the pods
 * Updated the default resources to match in-line with the recommended memory usage
 
 ## 2.0.0

--- a/charts/lightstepsatellite/values.yaml
+++ b/charts/lightstepsatellite/values.yaml
@@ -145,7 +145,7 @@ affinity: {}
 
 statsd:
   enabled: false
-  host: statsd-exporter
+  host: localhost                                   # localhost is required for the sidecar to work
   port: 9125
   export_statsd: true                               # If true, dogStatsD will be ignored
   prefix: "lightstep.prod.us-west-1"

--- a/charts/lightstepsatellite/values.yaml
+++ b/charts/lightstepsatellite/values.yaml
@@ -164,10 +164,10 @@ statsd:
     readOnlyRootFilesystem: true
     runAsNonRoot: true
     runAsUser: 1000
-  resources: {}
-    # limits:
-    #   memory: 20M
-    #   cpu: 1
-    # requests:
-    #   memory: 15M
-    #   cpu: 1
+  resources:
+    limits:
+      memory: 20M
+      cpu: 1
+    requests:
+      memory: 15M
+      cpu: 1


### PR DESCRIPTION
There are three distinct commits in this PR:

- Correct the default host for sidecar compatibility. Prior to this, the default values caused the exporting of metrics to the sidecar to fail.
- Add requests and limits to sidecar also. There are default values included for the main container but not for the sidecar prior to this commit.
- Corrected changelog entry