### PR TITLE
Fix lightstep_bytes metric in statsd mappings

### DIFF
--- a/charts/lightstepsatellite/templates/configmap-statsd-mapping.yaml
+++ b/charts/lightstepsatellite/templates/configmap-statsd-mapping.yaml
@@ -37,14 +37,22 @@ data:
           prefix: "{{ .Values.statsd.prefix }}"
           satellite_prefix: "{{ .Values.statsd.satellite_prefix }}"
           lightstep_project: "$2"
-      - match: "{{ .Values.statsd.prefix }}.{{ .Values.statsd.satellite_prefix }}.bytes.*.*"
+      - match: "{{ .Values.statsd.prefix }}.{{ .Values.statsd.satellite_prefix }}.bytes.received.*"
         name: "lightstep_bytes"
         match_metric_type: counter
         labels:
           prefix: "{{ .Values.statsd.prefix }}"
           satellite_prefix: "{{ .Values.statsd.satellite_prefix }}"
-          action: "$1"
-          protocol: "$2"
+          action: "received"
+          protocol: "$1"
+      - match: "{{ .Values.statsd.prefix }}.{{ .Values.statsd.satellite_prefix }}.bytes.indexed.*"
+        name: "lightstep_bytes"
+        match_metric_type: counter
+        labels:
+          prefix: "{{ .Values.statsd.prefix }}"
+          satellite_prefix: "{{ .Values.statsd.satellite_prefix }}"
+          action: "indexed"
+          lightstep_project: "$1"
       - match: "{{ .Values.statsd.prefix }}.{{ .Values.statsd.satellite_prefix }}.starts.*"
         name: "lightstep_starts"
         match_metric_type: counter

--- a/charts/lightstepsatellite/templates/configmap-statsd-mapping.yaml
+++ b/charts/lightstepsatellite/templates/configmap-statsd-mapping.yaml
@@ -31,7 +31,7 @@ data:
           action: "$1"
           lightstep_project: "$2"
       - match: "{{ .Values.statsd.prefix }}.{{ .Values.statsd.satellite_prefix }}.index.queue.*.*"
-        name: "lightstep_index_queue_${1}"
+        name: "lightstep_index_queue_$1"
         match_metric_type: gauge
         labels:
           prefix: "{{ .Values.statsd.prefix }}"


### PR DESCRIPTION
With the previous mappings the lightstep project would go into the protocol label.

From what I could see when running the satellites locally, when the action is `received`, the last section is indeed the protocol.
When the action is `indexed`, that last section is always the lightstep_project.

The change from `${1}` to `$1` fixes an issue we have internally with Spinnaker,
which converts ${1} into 1 when rendering the manifests.