### PR TITLE
microsat: add lightstep.max_msg_size_bytes to config

### DIFF
--- a/charts/lightstepsatellite/CHANGELOG.md
+++ b/charts/lightstepsatellite/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.10
+
+* Added `lightstep.max_msg_size_bytes` as a configuration option to override the maximum receive payload size for gRPC messages.
+
 ## 2.0.9
 
 * Downgraded PDB to use `policy/v1beta1`. It will work until k8s 1.25.

--- a/charts/lightstepsatellite/Chart.yaml
+++ b/charts/lightstepsatellite/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: lightstep
-version: 2.0.9
+version: 2.0.10
 appVersion: "2022-04-28_17-39-22Z"
 description: Lightstep microsatellite to collect telemetry data.
 home: https://lightstep.com/

--- a/charts/lightstepsatellite/README.md
+++ b/charts/lightstepsatellite/README.md
@@ -1,6 +1,6 @@
 # lightstep
 
-![Version: 2.0.8](https://img.shields.io/badge/Version-2.0.8-informational?style=flat-square) ![AppVersion: 2022-04-28_17-39-22Z](https://img.shields.io/badge/AppVersion-2022--04--28_17--39--22Z-informational?style=flat-square)
+![Version: 2.0.10](https://img.shields.io/badge/Version-2.0.10-informational?style=flat-square) ![AppVersion: 2022-04-28_17-39-22Z](https://img.shields.io/badge/AppVersion-2022--04--28_17--39--22Z-informational?style=flat-square)
 
 Lightstep microsatellite to collect telemetry data.
 
@@ -29,6 +29,7 @@ Lightstep microsatellite to collect telemetry data.
 | lightstep.guid | string | `nil` | defaults to pod's name using the Downward API |
 | lightstep.http_plain_port | int | `8181` |  |
 | lightstep.http_secure_port | int | `9191` |  |
+| lightstep.max_msg_size_bytes | int | `nil` |  |
 | lightstep.plain_port | int | `8383` |  |
 | lightstep.project_name | string | `""` | REQUIRED if `lightstep.disable_access_token_checking` is `true` |
 | lightstep.satelliteKey | string | `""` | REQUIRED: your Satellite Key - if not set, `lightstep.collector_satellite_key_secret_name` and `lightstep.collector_satellite_key_secret_key` must be set |

--- a/charts/lightstepsatellite/README.md
+++ b/charts/lightstepsatellite/README.md
@@ -29,7 +29,7 @@ Lightstep microsatellite to collect telemetry data.
 | lightstep.guid | string | `nil` | defaults to pod's name using the Downward API |
 | lightstep.http_plain_port | int | `8181` |  |
 | lightstep.http_secure_port | int | `9191` |  |
-| lightstep.max_msg_size_bytes | int | `nil` |  |
+| lightstep.max_msg_size_bytes | int | `0` |  |
 | lightstep.plain_port | int | `8383` |  |
 | lightstep.project_name | string | `""` | REQUIRED if `lightstep.disable_access_token_checking` is `true` |
 | lightstep.satelliteKey | string | `""` | REQUIRED: your Satellite Key - if not set, `lightstep.collector_satellite_key_secret_name` and `lightstep.collector_satellite_key_secret_key` must be set |

--- a/charts/lightstepsatellite/templates/deployment.yaml
+++ b/charts/lightstepsatellite/templates/deployment.yaml
@@ -116,6 +116,10 @@ spec:
             - name: COLLECTOR_STATSD_CLIENT_PREFIX
               value: {{ .Values.statsd.client_prefix | quote }}
             {{ end }}
+            {{ if .Values.lightstep.max_msg_size_bytes }}
+            - name: COLLECTOR_MAX_MSG_SIZE_BYTES
+              value: {{ .Values.lightstep.max_msg_size_bytes | quote }}
+            {{ end }}
           ports:
           - containerPort: {{ .Values.lightstep.diagnostic_port }}
             name: diagnostics

--- a/charts/lightstepsatellite/values.yaml
+++ b/charts/lightstepsatellite/values.yaml
@@ -120,7 +120,7 @@ lightstep:
   # Configure max gRPC receive message size in bytes.
   # https://pkg.go.dev/google.golang.org/grpc#MaxRecvMsgSize
   # Defaults to the library default of 4MiB.
-  max_msg_size_bytes:
+  max_msg_size_bytes: 0
 
 # Recommended resources would be 2Gi memory and 2 cpu
 resources:

--- a/charts/lightstepsatellite/values.yaml
+++ b/charts/lightstepsatellite/values.yaml
@@ -117,6 +117,10 @@ lightstep:
   secure_port: 9393
   tls_cert_prefix:
   collector_ingestion_tags:
+  # Configure max gRPC receive message size in bytes.
+  # https://pkg.go.dev/google.golang.org/grpc#MaxRecvMsgSize
+  # Defaults to the library default of 4MiB.
+  max_msg_size_bytes:
 
 # Recommended resources would be 2Gi memory and 2 cpu
 resources:


### PR DESCRIPTION
Just what it says on the tin. Let operators override the max payload size for inbound gRPC requests.