### PR TITLE
docs: fix readme generation

### DIFF
--- a/charts/lightstepsatellite/README.md
+++ b/charts/lightstepsatellite/README.md
@@ -29,7 +29,7 @@ Lightstep microsatellite to collect telemetry data.
 | lightstep.guid | string | `nil` | defaults to pod's name using the Downward API |
 | lightstep.http_plain_port | int | `8181` |  |
 | lightstep.http_secure_port | int | `9191` |  |
-| lightstep.max_msg_size_bytes | int | `0` | Configure max gRPC receive message size in bytes. https://pkg.go.dev/google.golang.org/grpc#MaxRecvMsgSize Defaults to the library default of 4MiB. |
+| lightstep.max_msg_size_bytes | int | `0` | Configure max gRPC receive message size in bytes. https://pkg.go.dev/google.golang.org/grpc#MaxRecvMsgSize Defaults to the library default of 4MiB if falsy. |
 | lightstep.plain_port | int | `8383` |  |
 | lightstep.project_name | string | `""` | REQUIRED if `lightstep.disable_access_token_checking` is `true` |
 | lightstep.satelliteKey | string | `""` | REQUIRED: your Satellite Key - if not set, `lightstep.collector_satellite_key_secret_name` and `lightstep.collector_satellite_key_secret_key` must be set |

--- a/charts/lightstepsatellite/README.md
+++ b/charts/lightstepsatellite/README.md
@@ -29,7 +29,7 @@ Lightstep microsatellite to collect telemetry data.
 | lightstep.guid | string | `nil` | defaults to pod's name using the Downward API |
 | lightstep.http_plain_port | int | `8181` |  |
 | lightstep.http_secure_port | int | `9191` |  |
-| lightstep.max_msg_size_bytes | int | `0` | Configure max gRPC receive message size in bytes. https://pkg.go.dev/google.golang.org/grpc#MaxRecvMsgSize Defaults to the library default of 4MiB. |
+| lightstep.max_msg_size_bytes | int | `nil` | Configure max gRPC receive message size in bytes. https://pkg.go.dev/google.golang.org/grpc#MaxRecvMsgSize Defaults to the library default of 4MiB. |
 | lightstep.plain_port | int | `8383` |  |
 | lightstep.project_name | string | `""` | REQUIRED if `lightstep.disable_access_token_checking` is `true` |
 | lightstep.satelliteKey | string | `""` | REQUIRED: your Satellite Key - if not set, `lightstep.collector_satellite_key_secret_name` and `lightstep.collector_satellite_key_secret_key` must be set |

--- a/charts/lightstepsatellite/README.md
+++ b/charts/lightstepsatellite/README.md
@@ -29,7 +29,7 @@ Lightstep microsatellite to collect telemetry data.
 | lightstep.guid | string | `nil` | defaults to pod's name using the Downward API |
 | lightstep.http_plain_port | int | `8181` |  |
 | lightstep.http_secure_port | int | `9191` |  |
-| lightstep.max_msg_size_bytes | int | `0` | Max gRPC server message size the microsatellite will accept. A value of 0 means the gRPC default of 4MiB |
+| lightstep.max_msg_size_bytes | int | `0` | Configure max gRPC receive message size in bytes. https://pkg.go.dev/google.golang.org/grpc#MaxRecvMsgSize Defaults to the library default of 4MiB. |
 | lightstep.plain_port | int | `8383` |  |
 | lightstep.project_name | string | `""` | REQUIRED if `lightstep.disable_access_token_checking` is `true` |
 | lightstep.satelliteKey | string | `""` | REQUIRED: your Satellite Key - if not set, `lightstep.collector_satellite_key_secret_name` and `lightstep.collector_satellite_key_secret_key` must be set |

--- a/charts/lightstepsatellite/README.md
+++ b/charts/lightstepsatellite/README.md
@@ -29,7 +29,7 @@ Lightstep microsatellite to collect telemetry data.
 | lightstep.guid | string | `nil` | defaults to pod's name using the Downward API |
 | lightstep.http_plain_port | int | `8181` |  |
 | lightstep.http_secure_port | int | `9191` |  |
-| lightstep.max_msg_size_bytes | int | `nil` | Configure max gRPC receive message size in bytes. https://pkg.go.dev/google.golang.org/grpc#MaxRecvMsgSize Defaults to the library default of 4MiB. |
+| lightstep.max_msg_size_bytes | int | `0` | Configure max gRPC receive message size in bytes. https://pkg.go.dev/google.golang.org/grpc#MaxRecvMsgSize Defaults to the library default of 4MiB. |
 | lightstep.plain_port | int | `8383` |  |
 | lightstep.project_name | string | `""` | REQUIRED if `lightstep.disable_access_token_checking` is `true` |
 | lightstep.satelliteKey | string | `""` | REQUIRED: your Satellite Key - if not set, `lightstep.collector_satellite_key_secret_name` and `lightstep.collector_satellite_key_secret_key` must be set |

--- a/charts/lightstepsatellite/templates/deployment.yaml
+++ b/charts/lightstepsatellite/templates/deployment.yaml
@@ -116,7 +116,7 @@ spec:
             - name: COLLECTOR_STATSD_CLIENT_PREFIX
               value: {{ .Values.statsd.client_prefix | quote }}
             {{ end }}
-            {{ if not (kindIs "invalid" .Values.lightstep.max_msg_size_bytes) }}
+            {{ if .Values.lightstep.max_msg_size_bytes }}
             - name: COLLECTOR_MAX_MSG_SIZE_BYTES
               value: {{ .Values.lightstep.max_msg_size_bytes | quote }}
             {{ end }}

--- a/charts/lightstepsatellite/templates/deployment.yaml
+++ b/charts/lightstepsatellite/templates/deployment.yaml
@@ -116,7 +116,7 @@ spec:
             - name: COLLECTOR_STATSD_CLIENT_PREFIX
               value: {{ .Values.statsd.client_prefix | quote }}
             {{ end }}
-            {{ if .Values.lightstep.max_msg_size_bytes }}
+            {{ if not (kindIs "invalid" .Values.lightstep.max_msg_size_bytes) }}
             - name: COLLECTOR_MAX_MSG_SIZE_BYTES
               value: {{ .Values.lightstep.max_msg_size_bytes | quote }}
             {{ end }}

--- a/charts/lightstepsatellite/values.yaml
+++ b/charts/lightstepsatellite/values.yaml
@@ -117,7 +117,7 @@ lightstep:
   secure_port: 9393
   tls_cert_prefix:
   collector_ingestion_tags:
-  # Configure max gRPC receive message size in bytes.
+  # -- Configure max gRPC receive message size in bytes.
   # https://pkg.go.dev/google.golang.org/grpc#MaxRecvMsgSize
   # Defaults to the library default of 4MiB.
   max_msg_size_bytes: 0

--- a/charts/lightstepsatellite/values.yaml
+++ b/charts/lightstepsatellite/values.yaml
@@ -119,7 +119,7 @@ lightstep:
   collector_ingestion_tags:
   # -- Configure max gRPC receive message size in bytes.
   # https://pkg.go.dev/google.golang.org/grpc#MaxRecvMsgSize
-  # Defaults to the library default of 4MiB.
+  # Defaults to the library default of 4MiB if falsy.
   max_msg_size_bytes: 0
 
 # Recommended resources would be 2Gi memory and 2 cpu

--- a/charts/lightstepsatellite/values.yaml
+++ b/charts/lightstepsatellite/values.yaml
@@ -117,10 +117,10 @@ lightstep:
   secure_port: 9393
   tls_cert_prefix:
   collector_ingestion_tags:
-  # -- (int) Configure max gRPC receive message size in bytes.
+  # -- Configure max gRPC receive message size in bytes.
   # https://pkg.go.dev/google.golang.org/grpc#MaxRecvMsgSize
   # Defaults to the library default of 4MiB.
-  max_msg_size_bytes:
+  max_msg_size_bytes: 0
 
 # Recommended resources would be 2Gi memory and 2 cpu
 resources:

--- a/charts/lightstepsatellite/values.yaml
+++ b/charts/lightstepsatellite/values.yaml
@@ -117,10 +117,10 @@ lightstep:
   secure_port: 9393
   tls_cert_prefix:
   collector_ingestion_tags:
-  # -- Configure max gRPC receive message size in bytes.
+  # -- (int) Configure max gRPC receive message size in bytes.
   # https://pkg.go.dev/google.golang.org/grpc#MaxRecvMsgSize
   # Defaults to the library default of 4MiB.
-  max_msg_size_bytes: 0
+  max_msg_size_bytes:
 
 # Recommended resources would be 2Gi memory and 2 cpu
 resources:


### PR DESCRIPTION
Looks like we just need a double hyphen to denote a values.yaml comment should be carried into docs.