### PR TITLE
Update version

### DIFF
--- a/charts/lightstepsatellite/CHANGELOG.md
+++ b/charts/lightstepsatellite/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.11
+
+* Incremental performance improvements
+* Improved microsatellite compression when using OpenTelemetry tracers
+* Image now based on Ubuntu 22.10
+
 ## 2.0.10
 
 * Added `lightstep.max_msg_size_bytes` as a configuration option to override the maximum receive payload size for gRPC messages.

--- a/charts/lightstepsatellite/Chart.yaml
+++ b/charts/lightstepsatellite/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: lightstep
-version: 2.0.10
-appVersion: "2022-04-28_17-39-22Z"
+version: 2.0.11
+appVersion: "2022-08-19_13-14-47Z"
 description: Lightstep microsatellite to collect telemetry data.
 home: https://lightstep.com/
 icon: https://go.lightstep.com/rs/260-KGM-472/images/logo-medium-color-400x100.jpg

--- a/charts/lightstepsatellite/README.md
+++ b/charts/lightstepsatellite/README.md
@@ -1,6 +1,6 @@
 # lightstep
 
-![Version: 2.0.10](https://img.shields.io/badge/Version-2.0.10-informational?style=flat-square) ![AppVersion: 2022-04-28_17-39-22Z](https://img.shields.io/badge/AppVersion-2022--04--28_17--39--22Z-informational?style=flat-square)
+![Version: 2.0.11](https://img.shields.io/badge/Version-2.0.11-informational?style=flat-square) ![AppVersion: 2022-08-19_13-14-47Z](https://img.shields.io/badge/AppVersion-2022--08--19_13--14--47Z-informational?style=flat-square)
 
 Lightstep microsatellite to collect telemetry data.
 
@@ -14,7 +14,7 @@ Lightstep microsatellite to collect telemetry data.
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"lightstep/microsatellite"` |  |
-| image.version | string | `"2022-04-28_17-39-22Z"` |  |
+| image.version | string | `"2022-08-19_13-14-47Z"` |  |
 | imagePullSecrets | list | `[]` |  |
 | lightstep.admin_plain_port | int | `8180` |  |
 | lightstep.admin_secure_port | int | `9090` |  |

--- a/charts/lightstepsatellite/values.yaml
+++ b/charts/lightstepsatellite/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 
 image:
   repository: lightstep/microsatellite
-  version: 2022-04-28_17-39-22Z
+  version: 2022-08-19_13-14-47Z
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
We updated our lightstep version to `2022-08-19_13-14-47Z` using this helm chart, but since it's not possible to set the `appVersion` at install time with helm, helm still shows the `appVersion` set in `Chart.yaml`, even if we are using the docker docker image `2022-08-19_13-14-47Z`, this could be confusing.

```
$ helm ls
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                           APP VERSION
lightstep       monitoring      1               2022-09-22     deployed        lightstep-2.0.10                 2022-04-28_17-39-22Z
```