### PR TITLE
feature: add autoscaling

### DIFF
--- a/charts/lightstepsatellite/CHANGELOG.md
+++ b/charts/lightstepsatellite/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.12
+
+* Add autoscaling via HorizontalPodAutoscaler. Set autoscaling.enabled=true to use it.
+
 ## 2.0.11
 
 * Incremental performance improvements

--- a/charts/lightstepsatellite/Chart.yaml
+++ b/charts/lightstepsatellite/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: lightstep
-version: 2.0.11
+version: 2.0.12
 appVersion: "2022-08-19_13-14-47Z"
 description: Lightstep microsatellite to collect telemetry data.
 home: https://lightstep.com/

--- a/charts/lightstepsatellite/README.md
+++ b/charts/lightstepsatellite/README.md
@@ -1,6 +1,6 @@
 # lightstep
 
-![Version: 2.0.11](https://img.shields.io/badge/Version-2.0.11-informational?style=flat-square) ![AppVersion: 2022-08-19_13-14-47Z](https://img.shields.io/badge/AppVersion-2022--08--19_13--14--47Z-informational?style=flat-square)
+![Version: 2.0.12](https://img.shields.io/badge/Version-2.0.12-informational?style=flat-square) ![AppVersion: 2022-08-19_13-14-47Z](https://img.shields.io/badge/AppVersion-2022--08--19_13--14--47Z-informational?style=flat-square)
 
 Lightstep microsatellite to collect telemetry data.
 
@@ -11,6 +11,13 @@ Lightstep microsatellite to collect telemetry data.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| autoscaling.behavior | object | `{}` |  |
+| autoscaling.enabled | bool | `false` |  |
+| autoscaling.maxReplicas | int | `25` |  |
+| autoscaling.minReplicas | int | `1` |  |
+| autoscaling.targetCPUUtilizationPercentage | int | `50` |  |
+| autoscaling.targetMemoryUtilizationPercentage | int | `50` |  |
+| autoscalingTemplate | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"lightstep/microsatellite"` |  |

--- a/charts/lightstepsatellite/templates/hpa.yaml
+++ b/charts/lightstepsatellite/templates/hpa.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.autoscaling.enabled -}}
+
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    {{- include "lightstep.labels" . | nindent 4 }}
+  name: {{ include "lightstep.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "lightstep.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+  {{- with .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.autoscaling.targetCPUUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.autoscalingTemplate }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- with .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/lightstepsatellite/values.yaml
+++ b/charts/lightstepsatellite/values.yaml
@@ -165,3 +165,34 @@ statsd:
     requests:
       memory: 15M
       cpu: 1
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 25
+  targetCPUUtilizationPercentage: 50
+  targetMemoryUtilizationPercentage: 50
+  behavior: {}
+    # scaleDown:
+    #   stabilizationWindowSeconds: 300
+    #  policies:
+    #   - type: Pods
+    #     value: 1
+    #     periodSeconds: 180
+    # scaleUp:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 2
+    #     periodSeconds: 60
+
+autoscalingTemplate: []
+# Custom or additional autoscaling metrics
+# ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-custom-metrics
+# - type: Pods
+#   pods:
+#     metric:
+#       name: my_app_requests_total
+#     target:
+#       type: AverageValue
+#       averageValue: 10000m


### PR DESCRIPTION
This adds autoscaling in the form of HPA so this is more usable in a production environment out-of-the-box.

I borrowed the abstraction from nginx-ingress. Since we're doomed to templating with Helm, I chose this one since it seemed flexible and neat.