### PR TITLE
fix: update config reference for diagnostic_port

### DIFF
--- a/charts/lightstepsatellite/CHANGELOG.md
+++ b/charts/lightstepsatellite/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.15
+
+* Fix `diagnostic_port` Helm variable to target the right config value.
+
 ## 2.0.14
 
 * Add `lightstep.sample_percent` for configuring sample percentage from the microsatellite. Note this can also be configured through the Lightstep API, and the API takes precedence.

--- a/charts/lightstepsatellite/Chart.yaml
+++ b/charts/lightstepsatellite/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: lightstep
-version: 2.0.14
+version: 2.0.15
 appVersion: "2022-10-03_20-16-42Z"
 description: Lightstep microsatellite to collect telemetry data.
 home: https://lightstep.com/

--- a/charts/lightstepsatellite/README.md
+++ b/charts/lightstepsatellite/README.md
@@ -1,6 +1,6 @@
 # lightstep
 
-![Version: 2.0.14](https://img.shields.io/badge/Version-2.0.14-informational?style=flat-square) ![AppVersion: 2022-10-03_20-16-42Z](https://img.shields.io/badge/AppVersion-2022--10--03_20--16--42Z-informational?style=flat-square)
+![Version: 2.0.15](https://img.shields.io/badge/Version-2.0.15-informational?style=flat-square) ![AppVersion: 2022-10-03_20-16-42Z](https://img.shields.io/badge/AppVersion-2022--10--03_20--16--42Z-informational?style=flat-square)
 
 Lightstep microsatellite to collect telemetry data.
 

--- a/charts/lightstepsatellite/templates/deployment.yaml
+++ b/charts/lightstepsatellite/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
             - name: COLLECTOR_REPORTER_BYTES_PER_PROJECT_OVERRIDES
               value: {{ .Values.lightstep.bytes_per_project_override | toJson | quote }}
             {{ end }}
-            - name: COLLECTOR_DIAGNOSTIC_PORT
+            - name: COLLECTOR_DIAGNOSTICS_PLAIN_PORT
               value: {{ .Values.lightstep.diagnostic_port | quote }}
             - name: COLLECTOR_ADMIN_PLAIN_PORT
               value: {{ .Values.lightstep.admin_plain_port | quote }}


### PR DESCRIPTION
This either referenced a config area that no longer exists, or was wrong all along.
This updates the reference to target the right config block for the diagnostics handler.