### PR TITLE
set deploy replicas conditionally

### DIFF
--- a/charts/lightstepsatellite/CHANGELOG.md
+++ b/charts/lightstepsatellite/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.16
+
+* Omit Deployment.spec.replicas if autoscaling is enabled, or replicaCount is null.
+
 ## 2.0.15
 
 * Fix `diagnostic_port` Helm variable to target the right config value.

--- a/charts/lightstepsatellite/templates/deployment.yaml
+++ b/charts/lightstepsatellite/templates/deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   labels:
     {{- include "lightstep.labels" . | nindent 4 }}
 spec:
+  {{- if not (or .Values.autoscaling.enabled (kindIs "invalid" .Values.replicaCount)) }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "lightstep.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
ref https://github.com/lightstep/lightstep-microsatellite-helm-chart/issues/25

If autoscaling is enabled, or replicaCount is null, omit deployment replicas. If it's HPA-powered, let it control the deploy replicas.