### PR TITLE
only set reporter_bytes_per_project if non-null

### DIFF
--- a/charts/lightstepsatellite/templates/deployment.yaml
+++ b/charts/lightstepsatellite/templates/deployment.yaml
@@ -63,8 +63,10 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             {{- end }}
+            {{- if not (kindIs "invalid" .Values.lightstep.bytes_per_project) }}
             - name: COLLECTOR_REPORTER_BYTES_PER_PROJECT
               value: {{ .Values.lightstep.bytes_per_project | quote }}
+            {{- end }}
             {{- if .Values.lightstep.bytes_per_project_override }}
             - name: COLLECTOR_REPORTER_BYTES_PER_PROJECT_OVERRIDES
               value: {{ .Values.lightstep.bytes_per_project_override | toJson | quote }}


### PR DESCRIPTION
ref https://github.com/lightstep/lightstep-microsatellite-helm-chart/issues/26

If lightstep.bytes_per_project is null, which is the default, don't set the env var.

Long as the CI lets me, I'll merge this and bump a patch version together with https://github.com/lightstep/lightstep-microsatellite-helm-chart/pull/27.