### PR TITLE
Fixes #32: Add check for policy/v1 support before falling back to v1beta1

### DIFF
--- a/charts/lightstepsatellite/templates/pdb.yaml
+++ b/charts/lightstepsatellite/templates/pdb.yaml
@@ -1,5 +1,8 @@
-# policy/v1beta1 support ends in 1.25, but only starts in 1.21.
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "lightstep.fullname" . }}-pdb


### PR DESCRIPTION
This should allow existing k8s versions to still work and add support for newer versions 1.25+