### PR TITLE
Remove v2beta2 from hpa

### DIFF
--- a/charts/lightstepsatellite/templates/hpa.yaml
+++ b/charts/lightstepsatellite/templates/hpa.yaml
@@ -1,10 +1,6 @@
 {{- if .Values.autoscaling.enabled -}}
 
-{{- if .Capabilities.APIVersions.Has "autoscaling/v2" -}}
 apiVersion: autoscaling/v2
-{{- else }}
-apiVersion: autoscaling/v2beta2
-{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   labels:


### PR DESCRIPTION
The autoscaling v2beta2 is no longer in any supported Kubernetes versions and should be removed from the Lightstep helm chart.