### PR TITLE
Remove v1beta1 policy api

### DIFF
--- a/charts/lightstepsatellite/templates/pdb.yaml
+++ b/charts/lightstepsatellite/templates/pdb.yaml
@@ -1,8 +1,4 @@
-{{- if .Capabilities.APIVersions.Has "policy/v1" }}
 apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "lightstep.fullname" . }}-pdb


### PR DESCRIPTION
The policy v1beta1 api is no longer in any supported Kubernetes versions and should be removed from the Lightstep helm chart.