### PR TITLE
LS-58080:(microsat-helm-chart): new microsat release update

### DIFF
--- a/charts/lightstepsatellite/CHANGELOG.md
+++ b/charts/lightstepsatellite/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.21
+
+* Update microsatellite image tag to `2024-01-22_17-52-59Z` to fix security vulnerabilites.
+
 ## 2.0.19
 
 * Update microsatellite image tag to `2023-07-31_19-36-12Z`.

--- a/charts/lightstepsatellite/Chart.yaml
+++ b/charts/lightstepsatellite/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: lightstep
-version: 2.0.20
-appVersion: "2023-07-31_19-36-12Z"
+version: 2.0.21
+appVersion: "2024-01-22_17-52-59Z"
 description: Lightstep microsatellite to collect telemetry data.
 home: https://lightstep.com/
 icon: https://go.lightstep.com/rs/260-KGM-472/images/logo-medium-color-400x100.jpg

--- a/charts/lightstepsatellite/README.md
+++ b/charts/lightstepsatellite/README.md
@@ -1,6 +1,6 @@
 # lightstep
 
-![Version: 2.0.20](https://img.shields.io/badge/Version-2.0.20-informational?style=flat-square) ![AppVersion: 2023-07-31_19-36-12Z](https://img.shields.io/badge/AppVersion-2023--07--31_19--36--12Z-informational?style=flat-square)
+![Version: 2.0.21](https://img.shields.io/badge/Version-2.0.20-informational?style=flat-square) ![AppVersion: 2024-01-22_17-52-59Z](https://img.shields.io/badge/AppVersion-2024--01--22_17--52--59Z-informational?style=flat-square)
 
 Lightstep microsatellite to collect telemetry data.
 
@@ -21,7 +21,7 @@ Lightstep microsatellite to collect telemetry data.
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"lightstep/microsatellite"` |  |
-| image.version | string | `"2023-07-31_19-36-12Z"` |  |
+| image.version | string | `"2024-01-22_17-52-59Z"` |  |
 | imagePullSecrets | list | `[]` |  |
 | lightstep.admin_plain_port | int | `8180` |  |
 | lightstep.admin_secure_port | int | `9090` |  |

--- a/charts/lightstepsatellite/README.md
+++ b/charts/lightstepsatellite/README.md
@@ -1,6 +1,6 @@
 # lightstep
 
-![Version: 2.0.21](https://img.shields.io/badge/Version-2.0.20-informational?style=flat-square) ![AppVersion: 2024-01-22_17-52-59Z](https://img.shields.io/badge/AppVersion-2024--01--22_17--52--59Z-informational?style=flat-square)
+![Version: 2.0.21](https://img.shields.io/badge/Version-2.0.21-informational?style=flat-square) ![AppVersion: 2024-01-22_17-52-59Z](https://img.shields.io/badge/AppVersion-2024--01--22_17--52--59Z-informational?style=flat-square)
 
 Lightstep microsatellite to collect telemetry data.
 

--- a/charts/lightstepsatellite/values.yaml
+++ b/charts/lightstepsatellite/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 
 image:
   repository: lightstep/microsatellite
-  version: 2023-07-31_19-36-12Z
+  version: 2024-01-22_17-52-59Z
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
Updates image tag for latest microsat release to `2024-01-22_17-52-59Z` tag. This new microsat release was needed to fix security vulnerabilities.